### PR TITLE
setup git-crypt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# pattern for locking with git-crypt
+# filepattern filter=git-crypt diff=git-crypt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.git-crypt.private.key


### PR DESCRIPTION
# setup git-crypt
## for safely including secrets in a public repo

it is very likely that we will eventually be using firebase
and that we'll need to share secrets around

[git-crypt](https://www.agwa.name/projects/git-crypt/) allows
us to do it by including the files directly in the repo in a
safe way

how to use
```
#install git-crypt
# instructions vary... oops?
# ask @kevinnls

cd <git repo>
git init
# get private key from @kevinnls
git unlock .git-crypt.private.key
# you should be able to use as usual
```
